### PR TITLE
Minor improvements to generate invoice form

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -235,7 +235,7 @@ func (l *lightningFaucet) zombieChanSweeper() {
 	// Every hour we'll consume a new tick and perform a sweep to close out
 	// any zombies channels.
 	zombieTicker := time.NewTicker(time.Hour * 1)
-	for _ = range zombieTicker.C {
+	for range zombieTicker.C {
 		log.Info("Performing zombie channel sweep!")
 
 		// In order to ensure we close out the proper channels, we also
@@ -363,7 +363,7 @@ func (l *lightningFaucet) closeChannel(chanPoint *lnrpc.ChannelPoint,
 // invalid channel submission, and finally a splash page upon successful
 // creation of a channel.
 type homePageContext struct {
-	// NumCoins is the number of coins in BTC that the faucet has available
+	// NumCoins is the number of coins in Decred that the faucet has available
 	// for channel creation.
 	NumCoins float64
 

--- a/faucet.go
+++ b/faucet.go
@@ -777,7 +777,6 @@ func (l *lightningFaucet) generateInvoice(homeTemplate *template.Template,
 		homeTemplate.Execute(w, homeState)
 		return
 	}
-	lastGeneratedInvoiceTime = time.Now()
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "unable to parse form", 500)
 		return
@@ -811,6 +810,7 @@ func (l *lightningFaucet) generateInvoice(homeTemplate *template.Template,
 		return
 	}
 
+	lastGeneratedInvoiceTime = time.Now()
 	log.Infof("Generated invoice #%d for %s rhash=%064x", invoice.AddIndex,
 		dcrutil.Amount(amtAtoms), invoice.RHash)
 

--- a/static/footer.html
+++ b/static/footer.html
@@ -18,7 +18,7 @@
           <div class="col-md-4 col-12 footer__credit-column h-100">
             <div class="d-flex justify-content-center h-100">
               <div class="align-self-center">
-                <p class="mb-0">Decred developers | 2019<br>The source sode is available on <a href="https://github.com/matheusd/lightning-faucet">GitHub</a>
+                <p class="mb-0">Decred developers | 2019<br>The source code is available on <a href="https://github.com/matheusd/lightning-faucet">GitHub</a>
                 </p>
               </div>
             </div>

--- a/static/index.html
+++ b/static/index.html
@@ -146,7 +146,7 @@
 
         <input class="form-control {{if eq .SubmissionError 3 10 11 12 }}is-invalid{{end}}"
         {{if .FormFields }}value="{{.FormFields.Amt}}"{{end}}
-        id="amt" name="amt" type="number" required="true" placeholder="0.01" max="0.2" step="0.0001">
+        id="amt" name="amt" type="number" required="true" value="0.01" max="0.2" step="0.0001">
 
         {{ if eq .SubmissionError 3 10 11 12 }}
           <div class="invalid-feedback">{{printf "%v" .SubmissionError}}</div>


### PR DESCRIPTION

- Initialise invoice form with a valid value
    - The form is a bit mis-leading without this. It appears as though the user can simply enter a description and hit "Generate Invoice", but this actually causes a validation error.
- Set LastInvoiceTime after invoice is created
   - The timer would start even if creating the invoice failed. This meant the user has to wait 60 seconds before they can try again.
- Fix typos in page footer and s/bitcoin/decred in comments